### PR TITLE
Update link to the docs repo

### DIFF
--- a/config/navbar.config.js
+++ b/config/navbar.config.js
@@ -107,7 +107,7 @@ module.exports = {
         //     ],
         // },
         {
-            href: "https://github.com/casper-network/docs-app",
+            href: "https://github.com/casper-network/docs",
             label: "GitHub",
             position: "right",
         },


### PR DESCRIPTION
### What does this PR fix/introduce?
I guess the repo was renamed from `docs-app` to `docs` but not updated in the navigation. This PR will update the link and removes the unecessary redirect.

### Additional context
N/A

### Checklist
- [X] Manually checked the link with Dev Tools and it seems to be unecessary because it is a 301 redirect only from GitHub.

### Reviewers
No idea